### PR TITLE
Add `onUrlClicked` event listening from Flutter & `hideMessanger` method.

### DIFF
--- a/android/src/main/kotlin/com/cbcloud/channel_io_flutter/ChannelIoFlutterPlugin.kt
+++ b/android/src/main/kotlin/com/cbcloud/channel_io_flutter/ChannelIoFlutterPlugin.kt
@@ -34,8 +34,8 @@ class ChannelIoFlutterPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
     channel = MethodChannel(flutterPluginBinding.binaryMessenger, "com.cbcloud/channel_io_flutter")
     channel.setMethodCallHandler(this)
 
-    val unreadEventChannel = EventChannel(flutterPluginBinding.binaryMessenger, ChannelIoFlutterPluginListener.EVENT_CHANNEL)
-    unreadEventChannel.setStreamHandler(channelIoFlutterPluginListener)
+    val eventChannel = EventChannel(flutterPluginBinding.binaryMessenger, ChannelIoFlutterPluginListener.EVENT_CHANNEL)
+    eventChannel.setStreamHandler(channelIoFlutterPluginListener)
 
     context = flutterPluginBinding.applicationContext
 
@@ -55,6 +55,9 @@ class ChannelIoFlutterPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
         }
         "showMessenger" -> {
           showMessenger(result)
+        }
+        "hideMessenger" -> {
+          hideMessenger(result)
         }
         "isBooted" -> {
           isBooted(result)
@@ -166,6 +169,14 @@ class ChannelIoFlutterPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
       result.error("UNAVAILABLE", "Channel Talk is not booted", null)
     }
     ChannelIO.showMessenger(activity)
+    result.success(true)
+  }
+
+  private fun hideMessenger(result: Result) {
+    if (!ChannelIO.isBooted()) {
+      result.error("UNAVAILABLE", "Channel Talk is not booted", null)
+    }
+    ChannelIO.hideMessenger()
     result.success(true)
   }
 

--- a/android/src/main/kotlin/com/cbcloud/channel_io_flutter/ChannelIoFlutterPlugin.kt
+++ b/android/src/main/kotlin/com/cbcloud/channel_io_flutter/ChannelIoFlutterPlugin.kt
@@ -34,8 +34,11 @@ class ChannelIoFlutterPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
     channel = MethodChannel(flutterPluginBinding.binaryMessenger, "com.cbcloud/channel_io_flutter")
     channel.setMethodCallHandler(this)
 
-    val eventChannel = EventChannel(flutterPluginBinding.binaryMessenger, ChannelIoFlutterPluginListener.EVENT_CHANNEL)
-    eventChannel.setStreamHandler(channelIoFlutterPluginListener)
+    val unreadEvent = EventChannel(flutterPluginBinding.binaryMessenger, ChannelIoFlutterPluginListener.UNREAD_EVENT_CHANNEL)
+    unreadEvent.setStreamHandler(channelIoFlutterPluginListener.unreadEventHandler)
+
+    val urlClickEvent = EventChannel(flutterPluginBinding.binaryMessenger, ChannelIoFlutterPluginListener.ON_URL_CLICKED_EVENT_CHANNEL)
+    urlClickEvent.setStreamHandler(channelIoFlutterPluginListener.onUrlClickEventHandler)
 
     context = flutterPluginBinding.applicationContext
 

--- a/android/src/main/kotlin/com/cbcloud/channel_io_flutter/ChannelIoFlutterPluginListener.kt
+++ b/android/src/main/kotlin/com/cbcloud/channel_io_flutter/ChannelIoFlutterPluginListener.kt
@@ -5,41 +5,18 @@ import com.zoyi.channel.plugin.android.open.model.PopupData
 import io.flutter.plugin.common.EventChannel
 import java.lang.IllegalArgumentException
 
-class ChannelIoFlutterPluginListener : ChannelPluginListener, EventChannel.StreamHandler {
+class ChannelIoFlutterPluginListener : ChannelPluginListener {
 
     companion object {
-        const val EVENT_CHANNEL = "com.cbcloud/channel_io_flutter/event"
+        const val UNREAD_EVENT_CHANNEL = "com.cbcloud/channel_io_flutter/unread"
+        const val ON_URL_CLICKED_EVENT_CHANNEL = "com.cbcloud/channel_io_flutter/on_url_clicked"
     }
 
-    // EventChannel.StreamHandler
-
-    private var mUnreadEventSink: EventChannel.EventSink? = null
-    private var mOnUrlClickEventSink: EventChannel.EventSink? = null
+    val unreadEventHandler: ChannelIoStreamHandler = ChannelIoStreamHandler()
+    val onUrlClickEventHandler: ChannelIoStreamHandler = ChannelIoStreamHandler()
 
     fun sendBadge(p0: Int) {
-        mUnreadEventSink?.success(p0)
-    }
-
-    override fun onListen(arguments: Any?, events: EventChannel.EventSink?) {
-        if (arguments == null) {
-            throw IllegalArgumentException("EventChannel arguments must be specified.")
-        }
-
-        when (arguments) {
-            "unread" -> mUnreadEventSink = events
-            "onUrlClicked" -> mOnUrlClickEventSink = events
-        }
-    }
-
-    override fun onCancel(arguments: Any?) {
-        if (arguments == null) {
-            throw IllegalArgumentException("EventChannel arguments must be specified.")
-        }
-
-        when (arguments) {
-            "unread" -> mUnreadEventSink = null
-            "onUrlClicked" -> mOnUrlClickEventSink = null
-        }
+        unreadEventHandler.mEventSink?.success(p0)
     }
 
     // ChannelPluginListener
@@ -47,14 +24,14 @@ class ChannelIoFlutterPluginListener : ChannelPluginListener, EventChannel.Strea
     override fun onUrlClicked(p0: String?): Boolean {
         if (p0 == null) return false
 
-        mOnUrlClickEventSink?.success(p0)
+        onUrlClickEventHandler.mEventSink?.success(p0)
         return true
     }
 
     override fun onProfileChanged(p0: String?, p1: Any?) {}
 
     override fun onBadgeChanged(p0: Int) {
-        mUnreadEventSink?.success(p0)
+        unreadEventHandler.mEventSink?.success(p0)
     }
 
     override fun onHideMessenger() {}
@@ -68,4 +45,18 @@ class ChannelIoFlutterPluginListener : ChannelPluginListener, EventChannel.Strea
     override fun onPopupDataReceived(p0: PopupData?) {}
 
     override fun onChatCreated(p0: String?) {}
+}
+
+class ChannelIoStreamHandler : EventChannel.StreamHandler {
+
+    var mEventSink: EventChannel.EventSink? = null
+        private set
+
+    override fun onListen(arguments: Any?, events: EventChannel.EventSink?) {
+        mEventSink = events
+    }
+
+    override fun onCancel(arguments: Any?) {
+        mEventSink = null
+    }
 }

--- a/android/src/main/kotlin/com/cbcloud/channel_io_flutter/ChannelIoFlutterPluginListener.kt
+++ b/android/src/main/kotlin/com/cbcloud/channel_io_flutter/ChannelIoFlutterPluginListener.kt
@@ -16,7 +16,7 @@ class ChannelIoFlutterPluginListener : ChannelPluginListener {
     val onUrlClickEventHandler: ChannelIoStreamHandler = ChannelIoStreamHandler()
 
     fun sendBadge(p0: Int) {
-        unreadEventHandler.mEventSink?.success(p0)
+        unreadEventHandler.eventSink?.success(p0)
     }
 
     // ChannelPluginListener
@@ -24,14 +24,14 @@ class ChannelIoFlutterPluginListener : ChannelPluginListener {
     override fun onUrlClicked(p0: String?): Boolean {
         if (p0 == null) return false
 
-        onUrlClickEventHandler.mEventSink?.success(p0)
-        return true
+        onUrlClickEventHandler.eventSink?.success(p0)
+        return onUrlClickEventHandler.isListened()
     }
 
     override fun onProfileChanged(p0: String?, p1: Any?) {}
 
     override fun onBadgeChanged(p0: Int) {
-        unreadEventHandler.mEventSink?.success(p0)
+        unreadEventHandler.eventSink?.success(p0)
     }
 
     override fun onHideMessenger() {}
@@ -49,14 +49,18 @@ class ChannelIoFlutterPluginListener : ChannelPluginListener {
 
 class ChannelIoStreamHandler : EventChannel.StreamHandler {
 
-    var mEventSink: EventChannel.EventSink? = null
+    var eventSink: EventChannel.EventSink? = null
         private set
 
+    fun isListened(): Boolean {
+        return eventSink != null
+    }
+
     override fun onListen(arguments: Any?, events: EventChannel.EventSink?) {
-        mEventSink = events
+        eventSink = events
     }
 
     override fun onCancel(arguments: Any?) {
-        mEventSink = null
+        eventSink = null
     }
 }

--- a/android/src/main/kotlin/com/cbcloud/channel_io_flutter/ChannelIoFlutterPluginListener.kt
+++ b/android/src/main/kotlin/com/cbcloud/channel_io_flutter/ChannelIoFlutterPluginListener.kt
@@ -3,37 +3,58 @@ package com.cbcloud.channel_io_flutter
 import com.zoyi.channel.plugin.android.open.listener.ChannelPluginListener
 import com.zoyi.channel.plugin.android.open.model.PopupData
 import io.flutter.plugin.common.EventChannel
+import java.lang.IllegalArgumentException
 
 class ChannelIoFlutterPluginListener : ChannelPluginListener, EventChannel.StreamHandler {
 
     companion object {
-        const val EVENT_CHANNEL = "com.cbcloud/channel_io_flutter/unread"
+        const val EVENT_CHANNEL = "com.cbcloud/channel_io_flutter/event"
     }
 
     // EventChannel.StreamHandler
 
-    private var mEventSink: EventChannel.EventSink? = null
+    private var mUnreadEventSink: EventChannel.EventSink? = null
+    private var mOnUrlClickEventSink: EventChannel.EventSink? = null
 
     fun sendBadge(p0: Int) {
-        mEventSink?.success(p0)
+        mUnreadEventSink?.success(p0)
     }
 
     override fun onListen(arguments: Any?, events: EventChannel.EventSink?) {
-        mEventSink = events
+        if (arguments == null) {
+            throw IllegalArgumentException("EventChannel arguments must be specified.")
+        }
+
+        when (arguments) {
+            "unread" -> mUnreadEventSink = events
+            "onUrlClicked" -> mOnUrlClickEventSink = events
+        }
     }
 
-    override fun onCancel(arguments: Any?) {}
+    override fun onCancel(arguments: Any?) {
+        if (arguments == null) {
+            throw IllegalArgumentException("EventChannel arguments must be specified.")
+        }
+
+        when (arguments) {
+            "unread" -> mUnreadEventSink = null
+            "onUrlClicked" -> mOnUrlClickEventSink = null
+        }
+    }
 
     // ChannelPluginListener
 
     override fun onUrlClicked(p0: String?): Boolean {
-        return false
+        if (p0 == null) return false
+
+        mOnUrlClickEventSink?.success(p0)
+        return true
     }
 
     override fun onProfileChanged(p0: String?, p1: Any?) {}
 
     override fun onBadgeChanged(p0: Int) {
-        mEventSink?.success(p0)
+        mUnreadEventSink?.success(p0)
     }
 
     override fun onHideMessenger() {}

--- a/ios/Classes/SwiftChannelIoFlutterPlugin.swift
+++ b/ios/Classes/SwiftChannelIoFlutterPlugin.swift
@@ -27,8 +27,8 @@ public class SwiftChannelIoFlutterPlugin: NSObject, FlutterPlugin {
         registrar.addMethodCallDelegate(plugin, channel: methodChannel)
         registrar.addApplicationDelegate(plugin)
         
-        let unreadEventChannel = FlutterEventChannel(name: "com.cbcloud/channel_io_flutter/unread", binaryMessenger: registrar.messenger())
-        unreadEventChannel.setStreamHandler(channelIoFlutterPluginHandler)
+        let eventChannel = FlutterEventChannel(name: "com.cbcloud/channel_io_flutter/event", binaryMessenger: registrar.messenger())
+        eventChannel.setStreamHandler(channelIoFlutterPluginHandler)
     }
     
     public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {

--- a/ios/Classes/SwiftChannelIoFlutterPlugin.swift
+++ b/ios/Classes/SwiftChannelIoFlutterPlugin.swift
@@ -10,6 +10,7 @@ public class SwiftChannelIoFlutterPlugin: NSObject, FlutterPlugin {
         case boot
         case shutdown
         case showMessenger
+        case hideMessenger
         case isBooted
         case setDebugMode
         case initPushToken
@@ -39,6 +40,8 @@ public class SwiftChannelIoFlutterPlugin: NSObject, FlutterPlugin {
             shutdown(call, result)
         case .showMessenger:
             showMessenger(call, result)
+        case .hideMessenger:
+            hideMessenger(call, result)
         case .isBooted:
             isBooted(call, result)
         case .setDebugMode:
@@ -129,6 +132,11 @@ public class SwiftChannelIoFlutterPlugin: NSObject, FlutterPlugin {
     
     private func showMessenger(_ call: FlutterMethodCall, _ result: @escaping FlutterResult) {
         ChannelIO.showMessenger()
+        result(true)
+    }
+    
+    private func hideMessenger(_ call: FlutterMethodCall, _ result: @escaping FlutterResult) {
+        ChannelIO.hideMessenger()
         result(true)
     }
     

--- a/ios/Classes/SwiftChannelIoFlutterPlugin.swift
+++ b/ios/Classes/SwiftChannelIoFlutterPlugin.swift
@@ -28,8 +28,11 @@ public class SwiftChannelIoFlutterPlugin: NSObject, FlutterPlugin {
         registrar.addMethodCallDelegate(plugin, channel: methodChannel)
         registrar.addApplicationDelegate(plugin)
         
-        let eventChannel = FlutterEventChannel(name: "com.cbcloud/channel_io_flutter/event", binaryMessenger: registrar.messenger())
-        eventChannel.setStreamHandler(channelIoFlutterPluginHandler)
+        let unreadEvent = FlutterEventChannel(name: "com.cbcloud/channel_io_flutter/unread", binaryMessenger: registrar.messenger())
+        unreadEvent.setStreamHandler(channelIoFlutterPluginHandler.unreadStreamHandler)
+        
+        let onUrlClickedEvent = FlutterEventChannel(name: "com.cbcloud/channel_io_flutter/on_url_clicked", binaryMessenger: registrar.messenger())
+        onUrlClickedEvent.setStreamHandler(channelIoFlutterPluginHandler.onUrlClickedStreamHandler)
     }
     
     public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {

--- a/ios/Classes/SwiftChannelIoFlutterPluginHandler.swift
+++ b/ios/Classes/SwiftChannelIoFlutterPluginHandler.swift
@@ -41,7 +41,7 @@ public class SwiftChannelIoFlutterPluginHandler: NSObject, ChannelPluginDelegate
 extension SwiftChannelIoFlutterPluginHandler: FlutterStreamHandler {
     public func onListen(withArguments arguments: Any?, eventSink events: @escaping FlutterEventSink) -> FlutterError? {
         guard let channel = arguments as? String else {
-            return FlutterError(code: "NOT_IMPLEMENTED", message: "Specified event channel is not implemented.", details: nil)
+            return FlutterError(code: "NOT_IMPLEMENTED", message: "EventChannel arguments must be specified.", details: nil)
         }
         
         switch(channel) {
@@ -58,7 +58,7 @@ extension SwiftChannelIoFlutterPluginHandler: FlutterStreamHandler {
     
     public func onCancel(withArguments arguments: Any?) -> FlutterError? {
         guard let channel = arguments as? String else {
-            return FlutterError(code: "NOT_IMPLEMENTED", message: "Specified event channel is not implemented.", details: nil)
+            return FlutterError(code: "NOT_IMPLEMENTED", message: "EventChannel arguments must be specified.", details: nil)
         }
         
         switch(channel) {

--- a/ios/Classes/SwiftChannelIoFlutterPluginHandler.swift
+++ b/ios/Classes/SwiftChannelIoFlutterPluginHandler.swift
@@ -20,7 +20,7 @@ public class SwiftChannelIoFlutterPluginHandler: NSObject, ChannelPluginDelegate
 
     public func onUrlClicked(url: URL) -> Bool {
         onUrlClickedStreamHandler.add(url.absoluteString)
-        return true
+        return onUrlClickedStreamHandler.isListened()
     }
     
     public func onProfileChanged(key: String, value: Any?) {}
@@ -45,6 +45,10 @@ public class ChannelIoStreamHandler: NSObject, FlutterStreamHandler {
         eventSink?(argument)
     }
     
+    public func isListened() -> Bool {
+        return eventSink != nil
+    }
+
     public func onListen(withArguments arguments: Any?, eventSink events: @escaping FlutterEventSink) -> FlutterError? {
         eventSink = events
         return nil

--- a/ios/Classes/SwiftChannelIoFlutterPluginHandler.swift
+++ b/ios/Classes/SwiftChannelIoFlutterPluginHandler.swift
@@ -11,20 +11,22 @@ import ChannelIOFront
 
 public class SwiftChannelIoFlutterPluginHandler: NSObject, ChannelPluginDelegate {
     
-    private var eventSink: FlutterEventSink?
+    private var unreadStreamSink: FlutterEventSink?
+    private var onUrlClickedStreamSink: FlutterEventSink?
     
     public func sendBadge(count: Int) {
-        eventSink?(count)
+        unreadStreamSink?(count)
     }
 
     public func onUrlClicked(url: URL) -> Bool {
-        return false
+        onUrlClickedStreamSink?(url.absoluteString)
+        return true
     }
     
     public func onProfileChanged(key: String, value: Any?) {}
     
     public func onBadgeChanged(count: Int) {
-        eventSink?(count)
+        unreadStreamSink?(count)
     }
     
     public func onHideMessenger() {}
@@ -38,12 +40,36 @@ public class SwiftChannelIoFlutterPluginHandler: NSObject, ChannelPluginDelegate
 
 extension SwiftChannelIoFlutterPluginHandler: FlutterStreamHandler {
     public func onListen(withArguments arguments: Any?, eventSink events: @escaping FlutterEventSink) -> FlutterError? {
-        eventSink = events
-        return nil
+        guard let channel = arguments as? String else {
+            return FlutterError(code: "NOT_IMPLEMENTED", message: "Specified event channel is not implemented.", details: nil)
+        }
+        
+        switch(channel) {
+        case "unread":
+            unreadStreamSink = events
+            return nil
+        case "onUrlClicked":
+            onUrlClickedStreamSink = events
+            return nil
+        default:
+            return nil
+        }
     }
     
     public func onCancel(withArguments arguments: Any?) -> FlutterError? {
-        eventSink = nil
-        return nil
+        guard let channel = arguments as? String else {
+            return FlutterError(code: "NOT_IMPLEMENTED", message: "Specified event channel is not implemented.", details: nil)
+        }
+        
+        switch(channel) {
+        case "unread":
+            unreadStreamSink = nil
+            return nil
+        case "onUrlClicked":
+            onUrlClickedStreamSink = nil
+            return nil
+        default:
+            return nil
+        }
     }
 }

--- a/ios/Classes/SwiftChannelIoFlutterPluginHandler.swift
+++ b/ios/Classes/SwiftChannelIoFlutterPluginHandler.swift
@@ -11,22 +11,22 @@ import ChannelIOFront
 
 public class SwiftChannelIoFlutterPluginHandler: NSObject, ChannelPluginDelegate {
     
-    private var unreadStreamSink: FlutterEventSink?
-    private var onUrlClickedStreamSink: FlutterEventSink?
+    public let unreadStreamHandler: ChannelIoStreamHandler = ChannelIoStreamHandler()
+    public let onUrlClickedStreamHandler: ChannelIoStreamHandler = ChannelIoStreamHandler()
     
     public func sendBadge(count: Int) {
-        unreadStreamSink?(count)
+        unreadStreamHandler.add(count)
     }
 
     public func onUrlClicked(url: URL) -> Bool {
-        onUrlClickedStreamSink?(url.absoluteString)
+        onUrlClickedStreamHandler.add(url.absoluteString)
         return true
     }
     
     public func onProfileChanged(key: String, value: Any?) {}
     
     public func onBadgeChanged(count: Int) {
-        unreadStreamSink?(count)
+        unreadStreamHandler.add(count)
     }
     
     public func onHideMessenger() {}
@@ -38,38 +38,20 @@ public class SwiftChannelIoFlutterPluginHandler: NSObject, ChannelPluginDelegate
     public func onChatCreated(chatId: String) {}
 }
 
-extension SwiftChannelIoFlutterPluginHandler: FlutterStreamHandler {
+public class ChannelIoStreamHandler: NSObject, FlutterStreamHandler {
+    private var eventSink: FlutterEventSink?
+    
+    public func add(_ argument: Any) {
+        eventSink?(argument)
+    }
+    
     public func onListen(withArguments arguments: Any?, eventSink events: @escaping FlutterEventSink) -> FlutterError? {
-        guard let channel = arguments as? String else {
-            return FlutterError(code: "NOT_IMPLEMENTED", message: "EventChannel arguments must be specified.", details: nil)
-        }
-        
-        switch(channel) {
-        case "unread":
-            unreadStreamSink = events
-            return nil
-        case "onUrlClicked":
-            onUrlClickedStreamSink = events
-            return nil
-        default:
-            return nil
-        }
+        eventSink = events
+        return nil
     }
     
     public func onCancel(withArguments arguments: Any?) -> FlutterError? {
-        guard let channel = arguments as? String else {
-            return FlutterError(code: "NOT_IMPLEMENTED", message: "EventChannel arguments must be specified.", details: nil)
-        }
-        
-        switch(channel) {
-        case "unread":
-            unreadStreamSink = nil
-            return nil
-        case "onUrlClicked":
-            onUrlClickedStreamSink = nil
-            return nil
-        default:
-            return nil
-        }
+        eventSink = nil
+        return nil
     }
 }

--- a/lib/channel_io_flutter.dart
+++ b/lib/channel_io_flutter.dart
@@ -18,6 +18,7 @@ class ChannelIoFlutter {
 
   static Stream<Uri?> get onUrlClicked => _onUrlClicked ??= _eventChannel
       .receiveBroadcastStream('onUrlClicked')
+      .where((event) => event is String)
       .map((event) => Uri.tryParse(event));
 
   static Future<bool> boot({

--- a/lib/channel_io_flutter.dart
+++ b/lib/channel_io_flutter.dart
@@ -5,13 +5,20 @@ import 'package:flutter/services.dart';
 class ChannelIoFlutter {
   static const MethodChannel _channel =
       const MethodChannel('com.cbcloud/channel_io_flutter');
-  static const EventChannel _unreadChannel =
-      const EventChannel('com.cbcloud/channel_io_flutter/unread');
+  static const EventChannel _eventChannel =
+      const EventChannel('com.cbcloud/channel_io_flutter/event');
+
+  static Stream<Uri?>? _onUrlClicked;
+  static Stream<dynamic>? _unreadStream;
 
   static Future<String> get platformVersion async {
     final String version = await _channel.invokeMethod('getPlatformVersion');
     return version;
   }
+
+  static Stream<Uri?> get onUrlClicked => _onUrlClicked ??= _eventChannel
+      .receiveBroadcastStream('onUrlClicked')
+      .map((event) => Uri.tryParse(event));
 
   static Future<bool> boot({
     required String pluginKey,
@@ -104,6 +111,6 @@ class ChannelIoFlutter {
   }
 
   static Stream<dynamic> getUnreadStream() {
-    return _unreadChannel.receiveBroadcastStream();
+    return _unreadStream ??= _eventChannel.receiveBroadcastStream('unread');
   }
 }

--- a/lib/channel_io_flutter.dart
+++ b/lib/channel_io_flutter.dart
@@ -5,8 +5,10 @@ import 'package:flutter/services.dart';
 class ChannelIoFlutter {
   static const MethodChannel _channel =
       const MethodChannel('com.cbcloud/channel_io_flutter');
-  static const EventChannel _eventChannel =
-      const EventChannel('com.cbcloud/channel_io_flutter/event');
+  static const EventChannel _unreadEventChannel =
+      const EventChannel('com.cbcloud/channel_io_flutter/unread');
+  static const EventChannel _onUrlClickedEventChannel =
+      const EventChannel('com.cbcloud/channel_io_flutter/on_url_clicked');
 
   static Stream<Uri?>? _onUrlClicked;
   static Stream<dynamic>? _unreadStream;
@@ -16,10 +18,11 @@ class ChannelIoFlutter {
     return version;
   }
 
-  static Stream<Uri?> get onUrlClicked => _onUrlClicked ??= _eventChannel
-      .receiveBroadcastStream('onUrlClicked')
-      .where((event) => event is String)
-      .map((event) => Uri.tryParse(event));
+  static Stream<Uri?> get onUrlClicked =>
+      _onUrlClicked ??= _onUrlClickedEventChannel
+          .receiveBroadcastStream()
+          .where((event) => event is String)
+          .map((event) => Uri.tryParse(event));
 
   static Future<bool> boot({
     required String pluginKey,
@@ -116,6 +119,6 @@ class ChannelIoFlutter {
   }
 
   static Stream<dynamic> getUnreadStream() {
-    return _unreadStream ??= _eventChannel.receiveBroadcastStream('unread');
+    return _unreadStream ??= _unreadEventChannel.receiveBroadcastStream();
   }
 }

--- a/lib/channel_io_flutter.dart
+++ b/lib/channel_io_flutter.dart
@@ -62,6 +62,10 @@ class ChannelIoFlutter {
     return await _channel.invokeMethod('showMessenger');
   }
 
+  static Future<bool> hideMessenger() async {
+    return await _channel.invokeMethod('hideMessenger');
+  }
+
   static Future<bool> isBooted() async {
     return await _channel.invokeMethod('isBooted');
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: channel_io_flutter
 description: A new flutter plugin project.
-version: 0.0.7
+version: 0.0.8
 author:
 homepage:
 


### PR DESCRIPTION
### 1. Added an `EventChannel` for listening `onUrlClicked` from Channel IO SDK.
To avoid some conflicts around `EventChannel` (In Android, an `EventChannel` can listen only once.), we have separated `ChannelPluginDelegate` (in Android: `ChannelPluginListener`) and `FlutterStreamHandler` (in Android: `StreamHandler`), and have made sure that `FlutterStreamHandler` is a composition of `ChannelPluginDelegate`.

### 2. Added `hideMessanger` method.

Just it's required.